### PR TITLE
fix: breaking change introducido en 1.1

### DIFF
--- a/src/SiiauConnector.php
+++ b/src/SiiauConnector.php
@@ -23,6 +23,8 @@ final class SiiauConnector extends Connector
 
     public ?int $retryInterval = 3000;
 
+    public ?bool $throwOnMaxTries = false;
+
     public function __construct(
         private readonly string $url,
     ) {}


### PR DESCRIPTION
Al integrar lo de cache login se quito el uso de un método deprecado de `sendAndRetry` y se implemento el retry en el conector principal. Esto introdujo un BC porque, por defecto, Saloon cuando activas lo de los retries si arroja un error al agotar los retries o que ya no se elija seguir reintentando con `handleRetry`.